### PR TITLE
Instantiate CacheableLookup only when needed

### DIFF
--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -31,7 +31,7 @@ import normalizePromiseArguments from '../as-promise/normalize-arguments';
 import {PromiseOnly} from '../as-promise/types';
 import calculateRetryDelay from './calculate-retry-delay';
 
-const globalDnsCache = new CacheableLookup();
+let globalDnsCache;
 
 type HttpRequestFunction = typeof httpRequest;
 type Error = NodeJS.ErrnoException;
@@ -1758,6 +1758,9 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 
 		// `options.dnsCache`
 		if (options.dnsCache === true) {
+			if (!globalDnsCache) {
+				globalDnsCache = new CacheableLookup();
+			}
 			options.dnsCache = globalDnsCache;
 		} else if (!is.undefined(options.dnsCache) && !options.dnsCache.lookup) {
 			throw new TypeError(`Parameter \`dnsCache\` must be a CacheableLookup instance or a boolean, got ${is(options.dnsCache)}`);


### PR DESCRIPTION
The `dnsCache` option is disabled by default but a `CacheableLookup` instance is always created. The proposed change is to instantiate CacheableLookup only when needed, which may make `got` a bit faster to load by default and when you do not use the DNS cache.

Moreover, the CacheableLookup class instantiates the DNS [`Resolver` class in NodeJS the standard library](https://nodejs.org/api/dns.html#dns_class_dnspromises_resolver), and the test framework [Jest](https://github.com/facebook/jest/) has a problem with it. It wrongly detects that something keeps running after the tests are finished, while it's just an instance of the DNS Resolver class. See https://github.com/facebook/jest/issues/6423

Jest should be fixed but meanwhile this small improvement in got may also hide the Jest issue for many developers.

#### Checklist

- [ ] I have read the documentation.
- [ ] I have included a pull request description of my changes.
- [ ] I have included some tests.
- [ ] If it's a new feature, I have included documentation updates in both the README and the types.
